### PR TITLE
Biotech gas mask tags fix

### DIFF
--- a/Biotech/Patches/ThingDefs_Misc/Apparel_BiotechHeadgear.xml
+++ b/Biotech/Patches/ThingDefs_Misc/Apparel_BiotechHeadgear.xml
@@ -165,6 +165,16 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Apparel_GasMask"]/apparel/tags</xpath>
+			<value>
+				<tags>
+					<li>IndustrialMilitaryBasic</li>
+					<li>GasMask</li>
+				</tags>
+		</value>
+	</Operation>
+
 	<!-- Cloth Mask  -->
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Apparel_ClothMask"]/statBases</xpath>


### PR DESCRIPTION
## Changes

The Biotech patch now copies over the tags of the Combat Extended gas mask apparel to the Biotech gas mask apparel.

## Reasoning

Why did you choose to implement things this way, e.g.
- Parity between the two smoke bombs
- Combat Extended has its own specific GasMask tag and the Biotech gas mask using the IndustrialBasic causes issues, like random pawns spawning with gas masks, that are not present in Combat Extended

## Alternatives

- Completely removing the item overlap:
  - Would be prefered, arguably leaving two different but identical items is a bit sloppy, but removals of those items were rejected in the past.

## Testing

Check tests you have performed:
- [X] Compiles without warnings
- [X] Game runs without errors
- [X] Playtested a colony (15 minutes, crafted some gas masks and made sure they worked fine)
